### PR TITLE
Using MidButton instead of MiddleButton

### DIFF
--- a/graph_view.py
+++ b/graph_view.py
@@ -400,7 +400,7 @@ class GraphView(QtGui.QGraphicsView):
             self.clearSelection(emitSignal=False)
             self._selectionRect = SelectionRect(graph=self, mouseDownPos=self.mapToScene(event.pos()))
 
-        elif event.button() is QtCore.Qt.MouseButton.MiddleButton:
+        elif event.button() is QtCore.Qt.MouseButton.MidButton:
 
             self.setCursor(QtCore.Qt.OpenHandCursor)
             self._manipulationMode = 2


### PR DESCRIPTION
**MiddleButton** is not defined on CentOS + PySide1.2.1 so changed the code to use the proper **MidButton**.

As detailed there, MiddleButton (if defined) is no more than an alias for MidButton so the code won't be affected on Windows:
http://doc.qt.io/qt-4.8/qt.html#MouseButton-en
