### PR TITLE
Setting the z-depth of the selected node(s) so they're always on top …

### DIFF
--- a/node.py
+++ b/node.py
@@ -205,6 +205,7 @@ class Node(QtGui.QGraphicsWidget):
         return self.__selected
 
     def setSelected(self, selected=True):
+        self.setZValue(10.0 if selected else 0.0)
         self.__selected = selected
         self.update()
 


### PR DESCRIPTION
Creating a dozen nodes and moving them around quickly display a problem with z values. Some nodes are **behind** and will always remain so, even when selected, which is counter-intuitive.

Fixed this behavior by forcing the zValue of selected nodes to 10.0. Non-selected nodes are set to a zValue of 0.0.

See screenshot:
![fix_zdepth](https://cloud.githubusercontent.com/assets/516321/12854833/c7fde91e-cc33-11e5-8e5f-91ce1b43e728.png)
